### PR TITLE
[FIX] issue_004: CPU usage and issue 003: Network Queue is Full

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -32,7 +32,7 @@ q_data_from_net = mp.Queue(10)
 # create functions for running each thread
 def opt_routine(q_data_to_lcd, q_data_from_net, q_data_to_net):
    '''
-      Controls all threads.
+      Control all threads.
    
    '''
    opt_t = ThreadOperation()


### PR DESCRIPTION
Fixed queue mechanism (send and receive) between
threads except operational thread. It uses to reduce cpu usage for threads (lcd and network).
It also solved issue 003, network queue is full.

Since we use block mechanism in queues, whenever queue is full, those don't raise an exception like it was (queue is Full). Instead, it's blocking the put and get queue method until new data is available.